### PR TITLE
Include parent directory in tmux session name

### DIFF
--- a/zsh/functions/tat
+++ b/zsh/functions/tat
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Attach or create tmux session named the same as current directory.
+# Attach or create tmux session named as the parent_directory/current_directory.
 
 not_in_tmux() {
   [ -z "$TMUX" ]
@@ -30,8 +30,9 @@ create_if_needed_and_attach() {
 }
 
 tat() {
-  path_name="$(basename "$PWD" | tr . -)"
-  session_name=${1-$path_name}
+  parent="$(basename "$(dirname "$PWD")")"
+  child="$(basename "$PWD" | tr . -)"
+  session_name=${1-"$parent/$child"}
 
   create_if_needed_and_attach
 }


### PR DESCRIPTION
I organize my git repositories in directories based on their purposes.
An example structure could be:

```
~/code/
  - client1/
    - project1/
    - project2/
  - client2/
    - project1/
    - project2/
```

Currently, `tat` creates a named session using the current directory
only. So if I'm in _~/code/client1/project2_, the session name will be
_project2_. Because I know _~/code/client2/project2_ exists, it's not
immediately obvious which client directory the session belongs to based
on _project2_ alone.

This updates `tat` to include the parent directory when creating a named
session, e.g. _client1/project2_, to give me more context when viewing
the session listing.
