### PR TITLE
Add git hooks to refresh ctags

### DIFF
--- a/git_template/hooks/ctags
+++ b/git_template/hooks/ctags
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+PATH="/usr/local/bin:$PATH"
+dir="$(git rev-parse --git-dir)"
+trap 'rm -f "$dir/$$.tags"' EXIT
+git ls-files | \
+  ctags --tag-relative -L - -f"$dir/$$.tags" --languages=-javascript,sql
+mv "$dir/$$.tags" "$dir/tags"

--- a/git_template/hooks/post-checkout
+++ b/git_template/hooks/post-checkout
@@ -1,0 +1,2 @@
+#!/bin/sh
+.git/hooks/ctags >/dev/null 2>&1 &

--- a/git_template/hooks/post-commit
+++ b/git_template/hooks/post-commit
@@ -1,0 +1,2 @@
+#!/bin/sh
+.git/hooks/ctags >/dev/null 2>&1 &

--- a/git_template/hooks/post-merge
+++ b/git_template/hooks/post-merge
@@ -1,0 +1,2 @@
+#!/bin/sh
+.git/hooks/ctags >/dev/null 2>&1 &

--- a/git_template/hooks/post-rewrite
+++ b/git_template/hooks/post-rewrite
@@ -1,0 +1,4 @@
+#!/bin/sh
+case "$1" in
+  rebase) exec .git/hooks/post-merge ;;
+esac

--- a/gitconfig
+++ b/gitconfig
@@ -48,3 +48,5 @@
   name = Chris Thorn
   email = chris@thorn.co
   signingkey = F8AC4201
+[init]
+  templatedir = ~/.git_template


### PR DESCRIPTION
Introduces a handful of git hooks to refresh ctags after the working
tree changes. Taken from [Tim Pope's blog](http://tbaggery.com/2011/08/08/effortless-ctags-with-git.html). His example has
JavaScript and SQL ignored by default, because ctags generates a lot of
warnings for them. I have also witnessed this when running ctags
manually, so I'm going to keep them disabled.

Initializing a repo with `git init`, including existing repos, will copy
the hooks and keep my tags up-to-date.
