### PR TITLE
Introduce git ss alias as `diff --shortstat`

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -22,6 +22,7 @@
   squash = "!git ci --squash $(git squash-target)"
   # first parent whose commit message does not contain squash! or fixup!
   squash-target = "!git log --oneline | grep -v 'squash!\\|fixup!' | head -n 1 | awk '{ print $1 }'"
+  ss = diff --shortstat
   todo = "!git grep TODO -- $(git diff --name-only ${1:-master}...HEAD)"
   wd = diff --word-diff
 [color]


### PR DESCRIPTION
When working on a feature branch, I often stop to check in on my current
diff size, to judge whether I should make an attempt to submit a pull
request with the work done so far, or continue implementing the feature.
I don't have any hard limits, but usually when a diff is in the
ballpark of 300 line changes, I'll make an attempt to submit a PR with
those isolated changes.

Note: this will only calculate stats for files already in the index,
e.g. new files won't be included unless they are added with `git add -N`
first.

Note: to calculate these stats on changes that have been staged, execute
`git ss --cached`. I don't think I do this often enough to warrant an
alias for it.
