### PR TITLE
Explicitly set indentation for .sql files

### DIFF
--- a/config/nvim/init.vim
+++ b/config/nvim/init.vim
@@ -59,6 +59,9 @@ set spell spellcapcheck=
 
 " Display extra whitespace
 set list listchars=tab:»\ ,trail:·,nbsp:·
+setlocal tabstop=2
+setlocal shiftwidth=2
+setlocal expandtab
 
 " Make it obvious where 80 characters is
 set textwidth=80


### PR DESCRIPTION
vim-sleuth has been great for almost every file type that I interact
with on a daily basis. However, because vim-sleuth's algorithm is based
on similarly typed files "near" the current file, it doesn't do anything
when it can't find a "match."

I will often open a temporary .sql file to write a complex query within
a Rails app, where no other .sql files exist. The default indentation is
hard tabs with a tabstop of 8, which is not what I want.

This sets the default config for all files to expand tabs to 2 spaces,
and display tabs characters as 2 spaces if they exist. If a project
follows a convention other than that, vim-sleuth will observe that and
make the necessary updates.

Will close #2
