### PR TITLE
Add git wip

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -25,6 +25,7 @@
   ss = diff --shortstat
   todo = "!git grep TODO -- $(git diff --name-only ${1:-master}...HEAD)"
   wd = diff --word-diff
+  wip = "!git ci -m 'WIP [ci skip]'"
 [color]
   ui = auto
 [commit]


### PR DESCRIPTION
I usually don't care about the CI status of the vast majority of work in
progress (WIP) commits that I make. Most CI services support skipping a
build when the commit contains a `[ci skip]` tag within its message.

This adds the `wip` git alias to commit with a WIP commit including the
ci skip tag.
