### PR TITLE
Add git alias to edit conflicts

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -7,6 +7,7 @@
   ci = commit -v
   co = checkout
   co-pr = !sh -c 'git fetch origin pull/$1/head:pr/$1 && git checkout pr/$1' -
+  conflicts = "!$EDITOR $(git diff --name-only --diff-filter=U)"
   d = diff
   dc = diff --cached
   fixup = "!git commit --fixup $(git squash-target)"


### PR DESCRIPTION
Adds `git conflicts` alias which launches `EDITOR` with the list of
conflicted files. With Vim, this allows me to fix  the conflicts in a
file and add it to the index, `:Gw`, then moving to the next one, `:n`,
with a rhythm that works well for me.
