### PR TITLE
Disable syntax highlighting

### DIFF
--- a/config/nvim/init.vim
+++ b/config/nvim/init.vim
@@ -49,7 +49,7 @@ augroup CursorLine
     au WinLeave * setlocal nocursorline
 augroup END
 
-syntax on
+syntax off
 
 " Better grammatical error styling
 highlight SpellBad ctermbg=NONE cterm=underline
@@ -167,13 +167,3 @@ endfunction
 
 let g:test#custom_strategies = {'neovim-tab': function('NeovimTabStrategy')}
 let g:test#strategy = 'neovim-tab'
-
-function! ToggleSyntax()
-  if exists("g:syntax_on")
-    syntax off
-  else
-    syntax enable
-  endif
-endfunction
-
-nnoremap <leader>s :call ToggleSyntax()<cr>


### PR DESCRIPTION
I tried this for awhile (bfa10c9c) and really enjoyed it, but rolled it
back (70a56b3) when having to deal with complex templating languages.
Shortly after, I added a quick way to toggle syntax on/off (40d3bb70),
with the idea of turning it off to do an in-editor review before
submitting a pull request. In reality this is something I rarely do, so
I haven't been getting the benefits of a colorless review. Thus, this
commit:
- Sets the default to `syntax off`
- Removes the maintenance burden of the rarely used toggle
