### PR TITLE
Define a custom color scheme

### DIFF
--- a/config/nvim/colors/hello.vim
+++ b/config/nvim/colors/hello.vim
@@ -1,0 +1,56 @@
+set background=light
+
+let g:colors_name="hello"
+
+hi clear
+
+hi Normal ctermbg=White ctermfg=Black
+
+hi Comment ctermfg=Black
+
+hi Constant ctermfg=Black
+hi String ctermfg=Black
+hi Character ctermfg=Black
+hi Number ctermfg=Black
+hi Boolean ctermfg=Black
+hi Float ctermfg=Black
+
+hi Identifier ctermfg=Black
+hi Function ctermfg=Black
+
+hi Statement ctermfg=Black
+hi Conditional ctermfg=Black
+hi Repeat ctermfg=Black
+hi Label ctermfg=Black
+hi Operator ctermfg=Black
+hi Keyword ctermfg=Black
+hi Exception ctermfg=Black
+
+hi PreProc ctermfg=Black
+hi Include ctermfg=Black
+hi Define ctermfg=Black
+hi Macro ctermfg=Black
+hi PreCondit ctermfg=Black
+
+hi Type ctermfg=Black
+hi StorageClass ctermfg=Black
+hi Structure ctermfg=Black
+hi Typedef ctermfg=Black
+
+hi Special ctermfg=Black
+hi SpecialChar ctermfg=Black
+hi Tag ctermfg=Black
+hi Delimiter ctermfg=Black
+hi SpecialComment ctermfg=Black
+hi Debug ctermfg=Black
+
+hi Underlined cterm=underline ctermfg=Black
+hi Ignore ctermfg=Black
+hi Error ctermfg=Black
+hi Todo ctermbg=Black ctermfg=White
+
+hi SpellBad cterm=underline ctermbg=White
+hi SpellCap cterm=underline ctermbg=White
+hi SpellRare cterm=underline ctermbg=White
+hi SpellLocal cterm=underline ctermbg=White
+

--- a/config/nvim/init.vim
+++ b/config/nvim/init.vim
@@ -51,12 +51,7 @@ augroup CursorLine
     au WinLeave * setlocal nocursorline
 augroup END
 
-syntax off
-
-" Better grammatical error styling
-highlight SpellBad ctermbg=NONE cterm=underline
-highlight SpellRare ctermbg=NONE cterm=underline
-highlight SpellCap ctermbg=NONE cterm=underline
+syntax on
 
 set spell spellcapcheck=
 
@@ -169,3 +164,5 @@ endfunction
 
 let g:test#custom_strategies = {'neovim-tab': function('NeovimTabStrategy')}
 let g:test#strategy = 'neovim-tab'
+
+colorscheme hello


### PR DESCRIPTION
Using `syntax off` has some downsides:
- vim-endwise stops completing Ruby blocks/methods with `end` keywords
- I lose the "ruby method" movement (is this provided by a plugin?)
- The `%` command does not support `do`/`end` in Ruby files

This change adds a custom color scheme where (most) everything is black
on white. The current exceptions that I know of are Todo comments, which
are white on black so they stand out like a sore thumb, and match
highlights, which are kept at the default yellow background. There may
be other syntax definitions I missed, but I'll tweak this as I discover
them.

![image](https://cloud.githubusercontent.com/assets/72176/17799892/81ef7ae2-6593-11e6-9d7a-2b62a7c02e11.png)
