### PR TITLE
Take notes in Vim

### DIFF
--- a/zsh/functions/note
+++ b/zsh/functions/note
@@ -1,0 +1,56 @@
+#!/usr/bin/env zsh
+
+NOTES_DIR=${NOTES_DIR:-~/.notes}
+
+new-note() {
+  context="$1"
+  if [ -z "$context" ]; then
+    echo "context expected" >&2
+    return 1
+  fi
+
+  datestamp=$(date +"%F")
+  tempfile="$(mktemp -t note).md"
+  $EDITOR "$tempfile"
+  mkdir -p "$NOTES_DIR/$context"
+  cat "$tempfile" >> "$NOTES_DIR/$context/$datestamp.md"
+  echo >> "$NOTES_DIR/$context/$datestamp.md"
+}
+
+find-note() {
+  pattern="$1"
+  if [ -z "$pattern" ]; then
+    echo "pattern expected" >&2
+    return 1
+  fi
+
+  note=$(ag --nogroup "$pattern" "$NOTES_DIR" | sed "s|$NOTES_DIR||" | selecta)
+  note_file=$(echo "$note" | cut -d : -f 1)
+  note_file_number=$(echo "$note" | cut -d : -f 2)
+  $EDITOR "+$note_file_number" "$NOTES_DIR/$note_file"
+}
+
+note() {
+  case "$1" in
+    ("new")
+      new-note "${@:2}"
+      ;;
+    ("find")
+      find-note "${@:2}"
+      ;;
+    (*)
+      echo "command expected" >&2
+      return 1
+      ;;
+  esac
+}
+
+_new-note-completion() {
+  completions="$(ls "$NOTES_DIR")"
+  reply=("${(ps:\n:)completions}")
+}
+
+compctl -k '(find new)' \
+  -x 'c[-1,find]' -k '()' \
+  - 'c[-1,new]' -K _new-note-completion \
+  -- note


### PR DESCRIPTION
I have a terrible memory, so I need to take lots of notes in order to
remember things. Every note taking application I have tried has just
enough friction that I end up failing to capture anything.

This adds a `note` command suite for capturing notes in Vim. It has two
commands so far:

* `note new <context>` - Opens Vim with a temp .md file. The buffer is
  empty, allowing me to focus on the current note. Once Vim is quit, the
  contents of that temp file are appended to a date stamped file under a
  directory named for the given `context`. The default notes directory
  is `~/.notes`, which I have symlinked to a directory in Dropbox. The
  context argument supports tab completion using existing contexts.
* `note find <pattern>` - Uses `ag` to search for `pattern` in the notes
  directory. The matched lines are fed through `selecta`. Selecting a
  result opens the note file for that day in Vim, with the cursor at the
  line number of the match.

It seems shellcheck does not support ZSH, so this code is pretty yolo.